### PR TITLE
Add documentation to the public interfaces

### DIFF
--- a/src/img.rs
+++ b/src/img.rs
@@ -1,5 +1,7 @@
 use image::GenericImageView;
 
+///Represents generic image data. `width` and `height` are the width and height of the image and
+///`pixel_buffer` is the raw pixel information of the image.
 #[derive(Default, Clone)]
 pub struct GenericImage {
     width: u32,
@@ -8,6 +10,7 @@ pub struct GenericImage {
 }
 
 impl GenericImage {
+    ///creates a new GenericImage with the given width, height, and pixel data
     pub fn new(width: u32, height: u32, pixel_buffer: Vec<u8>) -> Self {
         GenericImage {
             width,
@@ -17,8 +20,12 @@ impl GenericImage {
     }
 }
 
+///Image data to be passed to the input tensor. Provides handles to the dimensions of the image and
+/// the raw pixels of the image.
 pub trait DetectionImage {
+    ///Returns the dimensions of the image in the (width, height) pattern.
     fn dimension(&self) -> (u32, u32);
+    ///Returns a vector containing the raw pixel information.
     fn pixel_buffer(&self) -> Vec<u8>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,19 @@
+#![deny(missing_docs)]
+//! # Espial
+//! A library for performing object detection utilizing the Single Shot MultiBox
+//! Detector model created by google.
+//!
+//! Input for espial takes a type implementing the DetectionImage trait and performs object detection on
+//! that image. The list of objects that can be detected via the label map for the model can be found
+//! [here](https://github.com/tensorflow/models/blob/master/research/object_detection/data/mscoco_label_map.pbtxt)
+//!
+//! Output is returned as a hash map of the detection tensors containing the detection boxes, detection classes
+//! detection scores, and the number of detections. Each element of the returned HashMap can be accessed by the
+//! name of the tensor in all lower case separated by an underscore. (e.x. detection_scores)
+
+///Image module representing the input image to be inferenced.
 pub mod img;
+///ObjectDetection module that handles the setup and inferencing of the image data.
 pub mod obd;
 
 #[cfg(test)]

--- a/src/obd.rs
+++ b/src/obd.rs
@@ -6,6 +6,11 @@ use tensorflow::{
     Graph, ImportGraphDefOptions, Operation, Session, SessionOptions, SessionRunArgs, Tensor,
 };
 
+///Contains the Single Shot MultiBox Detector graph, the tensorflow session, and the image to inference.
+///
+/// ObjectDetection handles the initialization of the tensorflow session with the frozen graph. Converts the input image
+/// from raw pixels to the tensor shape we need for input. Feeds the input into the input tensor of the graph
+/// and returns the resulting output tensors in a HashMap.
 pub struct ObjectDetection {
     graph: Graph,
     sess: Session,
@@ -13,6 +18,7 @@ pub struct ObjectDetection {
 }
 
 impl ObjectDetection {
+    ///Initialize the tensorflow session with the frozen graph definition.
     pub fn init() -> Self {
         let mut graph = Graph::new();
         let proto =
@@ -29,8 +35,8 @@ impl ObjectDetection {
             image: Box::new(img::GenericImage::default()),
         }
     }
-
-    pub fn input<T: img::DetectionImage + 'static>(&mut self, image: T) {
+    ///Pass in the input image to be inferenced on. Input must implement the DetectionImage trait
+    pub fn input<I: img::DetectionImage + 'static>(&mut self, image: I) {
         self.image = Box::new(image);
     }
 
@@ -48,7 +54,8 @@ impl ObjectDetection {
 
         Ok((image_tensor_op, input_image_tensor))
     }
-
+    ///Run the inference on the inputted image transforming the image to the shape of the image input tensor,
+    ///performing the inferencing, and mapping the output tensors into the returned HashMap.
     pub fn run(&mut self) -> Result<HashMap<&str, Tensor<f32>>, Box<Error>> {
         let (image_tensor_op, input_image_tensor) = self.input_transform()?;
 


### PR DESCRIPTION
Closes #4 

Add some basic documentation to the public interfaces for the crate.

We still need to add some examples here but  I'm not 100% sure of a great way to do that without including images themselves which needs some investigation.