### PR TITLE
Explicitly return an ImageDimension type

### DIFF
--- a/src/img.rs
+++ b/src/img.rs
@@ -12,7 +12,7 @@ impl GenericImage {
     ///creates a new GenericImage with the given width, height, and pixel data
     pub fn new(width: u32, height: u32, pixel_buffer: Vec<u8>) -> Self {
         GenericImage {
-            image_dimension: ImageDimension{width, height},
+            image_dimension: ImageDimension { width, height },
             pixel_buffer,
         }
     }
@@ -49,7 +49,7 @@ impl DetectionImage for GenericImage {
 impl DetectionImage for image::DynamicImage {
     fn dimension(&self) -> ImageDimension {
         let (width, height) = self.dimensions();
-        ImageDimension{width, height}
+        ImageDimension { width, height }
     }
 
     fn pixel_buffer(&self) -> Vec<u8> {

--- a/src/img.rs
+++ b/src/img.rs
@@ -4,8 +4,7 @@ use image::GenericImageView;
 ///`pixel_buffer` is the raw pixel information of the image.
 #[derive(Default, Clone)]
 pub struct GenericImage {
-    width: u32,
-    height: u32,
+    image_dimension: ImageDimension,
     pixel_buffer: Vec<u8>,
 }
 
@@ -13,25 +12,33 @@ impl GenericImage {
     ///creates a new GenericImage with the given width, height, and pixel data
     pub fn new(width: u32, height: u32, pixel_buffer: Vec<u8>) -> Self {
         GenericImage {
-            width,
-            height,
+            image_dimension: ImageDimension{width, height},
             pixel_buffer,
         }
     }
 }
 
+///Dimensions (width and height) of an image
+#[derive(Clone, Copy, Default)]
+pub struct ImageDimension {
+    ///Width of the image.
+    pub width: u32,
+    ///Height of the image
+    pub height: u32,
+}
+
 ///Image data to be passed to the input tensor. Provides handles to the dimensions of the image and
 /// the raw pixels of the image.
 pub trait DetectionImage {
-    ///Returns the dimensions of the image in the (width, height) pattern.
-    fn dimension(&self) -> (u32, u32);
+    ///Returns the dimensions of the image
+    fn dimension(&self) -> ImageDimension;
     ///Returns a vector containing the raw pixel information.
     fn pixel_buffer(&self) -> Vec<u8>;
 }
 
 impl DetectionImage for GenericImage {
-    fn dimension(&self) -> (u32, u32) {
-        (self.width, self.height)
+    fn dimension(&self) -> ImageDimension {
+        self.image_dimension.clone()
     }
 
     fn pixel_buffer(&self) -> Vec<u8> {
@@ -40,8 +47,9 @@ impl DetectionImage for GenericImage {
 }
 
 impl DetectionImage for image::DynamicImage {
-    fn dimension(&self) -> (u32, u32) {
-        self.dimensions()
+    fn dimension(&self) -> ImageDimension {
+        let (width, height) = self.dimensions();
+        ImageDimension{width, height}
     }
 
     fn pixel_buffer(&self) -> Vec<u8> {

--- a/src/obd.rs
+++ b/src/obd.rs
@@ -41,15 +41,15 @@ impl ObjectDetection {
     }
 
     fn input_transform(&self) -> Result<(Operation, Tensor<u8>), Box<Error>> {
-        let (width, height) = self.image.dimension();
+        let image_dimension = self.image.dimension();
         let image_array = Array::from_shape_vec(
-            (height as usize, width as usize, 3),
+            (image_dimension.height as usize, image_dimension.width as usize, 3),
             self.image.pixel_buffer().to_vec(),
         )?;
         let image_array_expanded = image_array.insert_axis(Axis(0));
 
         let image_tensor_op = self.graph.operation_by_name_required("image_tensor")?;
-        let input_image_tensor = Tensor::new(&[1, u64::from(height), u64::from(width), 3])
+        let input_image_tensor = Tensor::new(&[1, u64::from(image_dimension.height), u64::from(image_dimension.width), 3])
             .with_values(image_array_expanded.as_slice().unwrap())?;
 
         Ok((image_tensor_op, input_image_tensor))

--- a/src/obd.rs
+++ b/src/obd.rs
@@ -43,14 +43,23 @@ impl ObjectDetection {
     fn input_transform(&self) -> Result<(Operation, Tensor<u8>), Box<Error>> {
         let image_dimension = self.image.dimension();
         let image_array = Array::from_shape_vec(
-            (image_dimension.height as usize, image_dimension.width as usize, 3),
+            (
+                image_dimension.height as usize,
+                image_dimension.width as usize,
+                3,
+            ),
             self.image.pixel_buffer().to_vec(),
         )?;
         let image_array_expanded = image_array.insert_axis(Axis(0));
 
         let image_tensor_op = self.graph.operation_by_name_required("image_tensor")?;
-        let input_image_tensor = Tensor::new(&[1, u64::from(image_dimension.height), u64::from(image_dimension.width), 3])
-            .with_values(image_array_expanded.as_slice().unwrap())?;
+        let input_image_tensor = Tensor::new(&[
+            1,
+            u64::from(image_dimension.height),
+            u64::from(image_dimension.width),
+            3,
+        ])
+        .with_values(image_array_expanded.as_slice().unwrap())?;
 
         Ok((image_tensor_op, input_image_tensor))
     }


### PR DESCRIPTION
Change the image module to represent `width` and `height` with an explicit type instead of the implicit ordering in a tuple.